### PR TITLE
Feature/add hide delay logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ import { LhtSpinnerModule } from 'cp-lht-spinner';
   imports: [
     BrowserModule,
     LhtSpinnerModule.forRoot({
-      spinnerDelayTime: 300, // optional
+      spinnerShowDelayTime: 300, // optional
+      spinnerHideDelayTime: 200, // optional
       spinnerSize: 100, // optional
       spinnerLoadingText: 'Custom text', // optional
     }),
@@ -68,8 +69,11 @@ The configuration model is defined as follows:
 
 ```ts
 export interface LhtSpinnerLibConfig {
-  readonly spinnerDelayTime?: number;
+  readonly spinnerShowDelayTime?: number;
   // Use this if you want to add delay before loading the spinner, im milliseconds
+
+  readonly spinnerHideDelayTime?: number;
+  // Use this if you want to add delay after loading the spinner, im milliseconds
 
   readonly spinnerSize?: number;
   // Use this if you want to make the spinner smaller or larger

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-lht-spinner",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-lht-spinner",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/cp-lht-spinner/package.json
+++ b/projects/cp-lht-spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-lht-spinner",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "peerDependencies": {
     "@angular/common": "^17.0.0",
     "@angular/core": "^17.0.0",

--- a/projects/cp-lht-spinner/package.json
+++ b/projects/cp-lht-spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-lht-spinner",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "peerDependencies": {
     "@angular/common": "^17.0.0",
     "@angular/core": "^17.0.0",

--- a/projects/cp-lht-spinner/src/lib/models/lht-spinner-lib-config.ts
+++ b/projects/cp-lht-spinner/src/lib/models/lht-spinner-lib-config.ts
@@ -1,5 +1,6 @@
 export interface LhtSpinnerLibConfig {
-  readonly spinnerDelayTime?: number;
+  readonly spinnerHideDelayTime?: number;
+  readonly spinnerShowDelayTime?: number;
   readonly spinnerSize?: number;
   readonly spinnerLoadingText?: string;
 }

--- a/projects/cp-lht-spinner/src/lib/models/lht-spinner-lib-config.ts
+++ b/projects/cp-lht-spinner/src/lib/models/lht-spinner-lib-config.ts
@@ -1,6 +1,6 @@
 export interface LhtSpinnerLibConfig {
-  readonly spinnerHideDelayTime?: number;
   readonly spinnerShowDelayTime?: number;
+  readonly spinnerHideDelayTime?: number;
   readonly spinnerSize?: number;
   readonly spinnerLoadingText?: string;
 }

--- a/projects/cp-lht-spinner/src/lib/services/lht-loading.service.ts
+++ b/projects/cp-lht-spinner/src/lib/services/lht-loading.service.ts
@@ -1,3 +1,4 @@
+
 import { Injectable } from '@angular/core';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
@@ -13,6 +14,7 @@ export class LhtLoadingService {
   private overlayRef: OverlayRef | null = null;
   private requestsCount = 0;
   private showTimer: any = null;
+  private hideTimer: any = null;
 
   constructor(
     private overlay: Overlay,
@@ -23,7 +25,7 @@ export class LhtLoadingService {
     this.requestsCount++;
 
     const delayTime =
-      this.lhtSpinnerSettingsService.libConfig.spinnerDelayTime || 0;
+      this.lhtSpinnerSettingsService.libConfig.spinnerShowDelayTime || 0;
 
     if (spinnerLoadingText) {
       this.lhtSpinnerSettingsService.setLibConfig({
@@ -34,6 +36,12 @@ export class LhtLoadingService {
 
     if (!this.overlayRef) {
       this.overlayRef = this.overlay.create();
+    }
+
+    if (this.hideTimer) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+      return;
     }
 
     if (this.showTimer === null) {
@@ -59,8 +67,21 @@ export class LhtLoadingService {
       this.requestsCount = 0;
 
       if (this.overlayRef && this.overlayRef.hasAttached()) {
-        this.overlayRef.detach();
+        this.removeOverlayRef(this.overlayRef);
       }
+    }
+  }
+
+  private removeOverlayRef(overlayRef: OverlayRef): void {
+    const hideDelay =
+      this.lhtSpinnerSettingsService.libConfig.spinnerHideDelayTime;
+
+    if (hideDelay) {
+      this.hideTimer = setTimeout(() => {
+        overlayRef.detach();
+      }, hideDelay);
+    } else {
+      overlayRef.detach();
     }
   }
 

--- a/projects/cp-lht-spinner/src/lib/services/lht-loading.service.ts
+++ b/projects/cp-lht-spinner/src/lib/services/lht-loading.service.ts
@@ -1,4 +1,3 @@
-
 import { Injectable } from '@angular/core';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';


### PR DESCRIPTION
Added functionality that delays the disappearing of the loading indicator by a set amount of time. This would ensure that the loading indicator does not 'flicker' when there are consecutive api calls.